### PR TITLE
Reduce Style from Enum to Struct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ansi_term"
 description = "Library for ANSI terminal colours and styles (bold, underline)"
 
-authors = [ "ogham@bsago.me" ]
+authors = [ "ogham@bsago.me", "Ryan Scheel (Havvy) <ryan.havvy@gmail.com>" ]
 documentation = "http://bsago.me/doc/ansi_term/"
 homepage = "https://github.com/ogham/rust-ansi-term"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -106,9 +106,9 @@ Fixed(221).on(Fixed(124)).paint("Mustard in the ketchup.")
 
 ## No Formatting
 
-Finally, for the sake of completeness, the Plain style provides
+Finally, for the sake of completeness, the default style provides
 neither colours nor formatting.
 
 ```rust
-Plain.paint("No colours here.")
+Style::default().paint("No colours here.")
 ```


### PR DESCRIPTION
The true power of this approach will be shown in my next PR where I start adding more methods.

I changed the struct names from `bold` and `underline` to `is_bold` and `is_underline` so they don't clash with the method names.

I did not keep anything named `Style::Plain`. I could add it as a method, but Style::default already exists.

I also made methods take a reference instead of consuming the value where appropriate.

This is a [Breaking Change].