### PR TITLE
Implement Color alias to Colour

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ documentation = "http://ogham.rustdocs.org/ansi_term/"
 homepage = "https://github.com/ogham/rust-ansi-term"
 license = "MIT"
 readme = "README.md"
-version = "0.7.2"
+version = "0.7.3"
 
 [lib]
 name = "ansi_term"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,6 +259,9 @@ pub enum Colour {
     Fixed(u8),
 }
 
+/// Color is a type alias for Colour for those who can't be bothered.
+pub use Colour as Color;
+
 // I'm not beyond calling Colour Colour, rather than Color, but I did
 // purposefully name this crate 'ansi-term' so people wouldn't get
 // confused when they tried to install it.


### PR DESCRIPTION
I thought this was sufficiently silly, so feel free to reject this PR.

Rust is nice because we can alias exports and we don't have to argue over the Queen's spelling vs. patriotic way to spell color.

I was able to verify that this does allow for one to `use ansi_color::Color::Green`

This PR may be accompanied by changes to the readme or modifications to the version.