### PR TITLE
Fix the colour chart link for `Colour::Fixed(u8)`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,8 +254,8 @@ pub enum Colour {
     ///   arranged in six squares measuring six by six each.
     /// - Colours 232 to 255 are shades of grey from black to white.
     ///
-    /// It might make more sense to look at a [colour chart](^cc).
-    /// [^cc]: https://upload.wikimedia.org/wikipedia/en/1/15/Xterm_256color_chart.svg
+    /// It might make more sense to look at a [colour chart][cc].
+    /// [cc]: https://upload.wikimedia.org/wikipedia/en/1/15/Xterm_256color_chart.svg
     Fixed(u8),
 }
 


### PR DESCRIPTION
When looking through the docs for some pointers towards designing my own library for ANSI colours I found that the link to the colour chart was broken. I thought I may as well submit a PR fixing it since I'm basically copying your API :wink: 