### PR TITLE
Support setting the foreground on an existing Style

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ println!("Yellow on blue: {}", Yellow.on(Blue).paint("wow!"));
 The complete list of styles you can use are:
 `bold`, `dimmed`, `italic`, `underline`, `blink`, `reverse`, `hidden`, and `on` for background colours.
 
+In some cases, you may find it easier to change the foreground on an existing `Style` rather than starting from the appropriate `Colour`.
+You can do this using the `fg` method:
+
+```rust
+    use ansi_term::Style;
+    use ansi_term::Colour::{Blue, Cyan, Yellow};
+    println!("Yellow on blue: {}", Style::new().on(Blue).fg(Yellow).paint("yow!"));
+    println!("Also yellow on blue: {}", Cyan.on(Blue).fg(Yellow).paint("zow!"));
+```
+
 Finally, you can turn a `Colour` into a `Style` with the `normal` method.
 This will produce the exact same `ANSIString` as if you just used the `paint` method on the `Colour` directly, but it’s useful in certain cases: for example, you may have a method that returns `Styles`, and need to represent both the “red bold” and “red, but not bold” styles with values of the same type. The `Style` struct also has a `Default` implementation if you want to have a style with *nothing* set.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,15 @@
 //! The complete list of styles you can use are: `bold`, `dimmed`, `italic`,
 //! `underline`, `blink`, `reverse`, `hidden`, and `on` for background colours.
 //!
+//! In some cases, you may find it easier to change the foreground on an
+//! existing `Style` rather than starting from the appropriate `Colour`.
+//! You can do this using the `fg` method:
+//!
+//!     use ansi_term::Style;
+//!     use ansi_term::Colour::{Blue, Cyan, Yellow};
+//!     println!("Yellow on blue: {}", Style::new().on(Blue).fg(Yellow).paint("yow!"));
+//!     println!("Also yellow on blue: {}", Cyan.on(Blue).fg(Yellow).paint("zow!"));
+//!
 //! Finally, you can turn a `Colour` into a `Style` with the `normal` method.
 //! This will produce the exact same `ANSIString` as if you just used the
 //! `paint` method on the `Colour` directly, but it’s useful in certain cases:
@@ -419,6 +428,11 @@ impl Style {
         Style { is_hidden: true, .. *self }
     }
 
+    /// Returns a Style with the foreground colour property set.
+    pub fn fg(&self, foreground: Colour) -> Style {
+        Style { foreground: Some(foreground), .. *self }
+    }
+
     /// Returns a Style with the background colour property set.
     pub fn on(&self, background: Colour) -> Style {
         Style { background: Some(background), .. *self }
@@ -699,6 +713,8 @@ mod tests {
     test!(green_bold_ul_2:       Green.underline().bold();          "hi" => "\x1B[1;4;32mhi\x1B[0m");
     test!(purple_on_white:       Purple.on(White);                  "hi" => "\x1B[47;35mhi\x1B[0m");
     test!(purple_on_white_2:     Purple.normal().on(White);         "hi" => "\x1B[47;35mhi\x1B[0m");
+    test!(yellow_on_blue:        Style::new().on(Blue).fg(Yellow);  "hi" => "\x1B[44;33mhi\x1B[0m");
+    test!(yellow_on_blue_2:      Cyan.on(Blue).fg(Yellow);          "hi" => "\x1B[44;33mhi\x1B[0m");
     test!(cyan_bold_on_white:    Cyan.bold().on(White);             "hi" => "\x1B[1;47;36mhi\x1B[0m");
     test!(cyan_ul_on_white:      Cyan.underline().on(White);        "hi" => "\x1B[4;47;36mhi\x1B[0m");
     test!(cyan_bold_ul_on_white: Cyan.bold().underline().on(White); "hi" => "\x1B[1;4;47;36mhi\x1B[0m");


### PR DESCRIPTION
Add a .fg method to Style to set the foreground Colour.  This simplifies
color parsers that need to handle attributes before the first color,
such as parsing "bold green" into Style::new().bold().fg(Green).