### PR TITLE
Added a method to enable ansi support under windows 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ use std::string::ToString;
 let red_string = Red.paint("a red string").to_string();
 ```
 
+Note for windows 10 users:: On windows 10 the application must enable ansi support.
+
+```rust
+let maybe_error_code = ansi_term::enable_ansi_support();
+```
 
 ## Bold, underline, background, and other styles
 


### PR DESCRIPTION
On windows 10, applications must call [Kernel32/SetConsoleMode] to enable ansi support.

This proposed change exposes a method to do just that.