### PR TITLE
Fix build fail with i686 toolchain

### DIFF
--- a/src/windows.rs
+++ b/src/windows.rs
@@ -10,14 +10,14 @@
 pub fn enable_ansi_support() -> Result<(), u64> {
 
     #[link(name = "kernel32")]
-    extern {
-        fn GetStdHandle(handle: u64) -> *const i32;
+    extern "system" {
+        fn GetStdHandle(handle: u32) -> *const i32;
         fn SetConsoleMode(handle: *const i32, mode: u32) -> bool;
         fn GetLastError() -> u64;
     }
 
     unsafe {
-        const STD_OUT_HANDLE: u64 = -11i32 as u64;
+        const STD_OUT_HANDLE: u32 = -11i32 as u32;
         const ENABLE_ANSI_CODES: u32 = 7;
 
         // https://msdn.microsoft.com/en-us/library/windows/desktop/ms683231(v=vs.85).aspx


### PR DESCRIPTION
As noted in #31, I was experiencing a similar linker error and failure with the i686 toolchain. I had some time to dig into it a little bit and I believe I have a resolution for this issue that I would like to share.

The problem appeared to be the calling convention for the kernel32 DLL function and a  `u64` being used even with the i686 (32-bit) toolchain. [Apparently on Windows](https://stackoverflow.com/questions/39419/how-large-is-a-dword-with-32-and-64-bit-code), a `DWORD` is always 32-bit (u32) even on a 64-bit system (x86_64). The `GetStdHandle` declaration was using a u64.

Additionally, the `system` calling convention needed to be added because in 64-bit environments (x86_64), the calling convention is `C` but in 32-bit environments the calling convention is `stdcall`, as noted in the [Rust book's FFI section](https://doc.rust-lang.org/book/first-edition/ffi.html#foreign-calling-conventions):

>Most of the abis in this list are self-explanatory, but the system abi may seem a little odd. This constraint selects whatever the appropriate ABI is for interoperating with the target's libraries. For example, on win32 with a x86 architecture, this means that the abi used would be stdcall. On x86_64, however, windows uses the C calling convention, so C would be used. This means that in our previous example, we could have used extern "system" { ... } to define a block for all windows systems, not only x86 ones.

The `system` calling convention automatically handles the difference depending on the environment/toolchain. Without this notation, the linker would fail because the calling convention would not match the declarations for all three functions.

After making these changes, I was able to successfully build the crate using the `stable-i686-pc-windows-msvc` toolchain with a x86 environment (Developer Prompt for x86) and pass all tests. I was also able to successfully build the crate with the `stable-x86_64-pc-windows-msvc`. I used the following commands from the x86 Developer Prompt on a 64-bit architecture running Windows 10 to build and pass the tests that were previously failing to build because of the linker error:

```dos
C:\set RUSTUP_TOOLCHAIN=stable-i686-pc-windows-msvc
C:\cargo test
...
test result: ok. 56 passed; 0 failed, 0 ignored; 0 measured; 0 filtered out
...
test result: ok. 18 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```