### PR TITLE
clippy: Fix clone on copy warning.

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -35,7 +35,7 @@ impl<'a, S: 'a + ToOwned + ?Sized> Clone for ANSIGenericString<'a, S>
 where <S as ToOwned>::Owned: fmt::Debug {
     fn clone(&self) -> ANSIGenericString<'a, S> {
         ANSIGenericString {
-            style: self.style.clone(),
+            style: self.style,
             string: self.string.clone(),
         }
     }


### PR DESCRIPTION
Calling `clone` here triggers a warning in clippy because the type
is already a `Copy` type.