### PR TITLE
Optional serde serialization feature for colours and styles & a minor fix for Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,17 @@ version = "0.11.0"
 [lib]
 name = "ansi_term"
 
+[features]
+derive_serde_style = ["serde"]
+
+[dependencies.serde]
+version = "1.0.90"
+features = ["derive"]
+optional = true
+
 [target.'cfg(target_os="windows")'.dependencies.winapi]
 version = "0.3.4"
-features = ["errhandlingapi", "consoleapi", "processenv"]
+features = ["errhandlingapi", "consoleapi", "processenv", "handleapi"]
+
+[dev-dependencies.serde_json]
+version = "1.0.39"


### PR DESCRIPTION
I added optional derives of serde's `Serialize` and `Deserialize`. The idea is to allow serialization of configuration structs that would themselves use serde.

Example usage:
```rust
#[derive(Serialize, Deserialize)]
pub struct Config {
  pub user_name_style: Style,
  pub highlight_colour: Colour,
}
```