### PR TITLE
Add doc-comment to test README examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ name = "ansi_term"
 [target.'cfg(target_os="windows")'.dependencies.winapi]
 version = "0.3.4"
 features = ["errhandlingapi", "consoleapi", "processenv"]
+
+[dev-dependencies]
+doc-comment = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://github.com/ogham/rust-ansi-term"
 license = "MIT"
 readme = "README.md"
 version = "0.11.0"
+repository = "https://github.com/ogham/rust-ansi-term"
 
 [lib]
 name = "ansi_term"

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ let red_string = Red.paint("a red string").to_string();
 
 **Note for Windows 10 users:** On Windows 10, the application must enable ANSI support first:
 
-```rust
+```rust,ignore
 let enabled = ansi_term::enable_ansi_support();
 ```
 
@@ -81,10 +81,10 @@ In some cases, you may find it easier to change the foreground on an existing `S
 You can do this using the `fg` method:
 
 ```rust
-    use ansi_term::Style;
-    use ansi_term::Colour::{Blue, Cyan, Yellow};
-    println!("Yellow on blue: {}", Style::new().on(Blue).fg(Yellow).paint("yow!"));
-    println!("Also yellow on blue: {}", Cyan.on(Blue).fg(Yellow).paint("zow!"));
+use ansi_term::Style;
+use ansi_term::Colour::{Blue, Cyan, Yellow};
+println!("Yellow on blue: {}", Style::new().on(Blue).fg(Yellow).paint("yow!"));
+println!("Also yellow on blue: {}", Cyan.on(Blue).fg(Yellow).paint("zow!"));
 ```
 
 Finally, you can turn a `Colour` into a `Style` with the `normal` method.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,6 +177,12 @@
 
 #[cfg(target_os="windows")]
 extern crate winapi;
+#[cfg(test)]
+#[macro_use]
+extern crate doc_comment;
+
+#[cfg(test)]
+doctest!("../README.md");
 
 mod ansi;
 pub use ansi::{Prefix, Infix, Suffix};


### PR DESCRIPTION
Allows to keep in check the README file examples.

I also added the repository link for `crates.io` users to make your crate easier to find (so you should maybe publish it once this PR is merged?).