### PR TITLE
Fix windows compilation errors

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,7 +26,7 @@ environment:
 
   matrix:
   # minimum version
-  - CHANNEL: 1.17.0
+  - CHANNEL: 1.28.0
     ARCH: i686
     ABI: msvc
   # "msvc" ABI

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ features = ["consoleapi", "errhandlingapi", "fileapi", "handleapi", "processenv"
 
 [dev-dependencies]
 doc-comment = "0.3"
+regex = "1.1.9"
 
 [dev-dependencies.serde_json]
 version = "1.0.39"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ optional = true
 
 [target.'cfg(target_os="windows")'.dependencies.winapi]
 version = "0.3.4"
-features = ["errhandlingapi", "consoleapi", "processenv", "handleapi"]
+features = ["consoleapi", "errhandlingapi", "fileapi", "handleapi", "processenv"]
 
 [dev-dependencies]
 doc-comment = "0.3"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rust-ansi-term [![ansi-term on crates.io](http://meritbadge.herokuapp.com/ansi-term)](https://crates.io/crates/ansi_term) [![Build status](https://travis-ci.org/ogham/rust-ansi-term.svg?branch=master)](https://travis-ci.org/ogham/rust-ansi-term) [![Coverage status](https://coveralls.io/repos/ogham/rust-ansi-term/badge.svg?branch=master&service=github)](https://coveralls.io/github/ogham/rust-ansi-term?branch=master)
+# rust-ansi-term [![ansi-term on crates.io](http://meritbadge.herokuapp.com/ansi-term)](https://crates.io/crates/ansi_term) [![Build status](https://img.shields.io/travis/ogham/rust-ansi-term/master.svg?style=flat)](https://travis-ci.org/ogham/rust-ansi-term) [![Build status](https://img.shields.io/appveyor/ci/ogham/rust-ansi-term/master.svg?style=flat&logo=AppVeyor&logoColor=silver)](https://ci.appveyor.com/project/ogham/rust-ansi-term) [![Coverage status](https://coveralls.io/repos/ogham/rust-ansi-term/badge.svg?branch=master&service=github)](https://coveralls.io/github/ogham/rust-ansi-term?branch=master)
 
 This is a library for controlling colours and formatting, such as red bold text or blue underlined text, on ANSI terminals.
 

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -2,7 +2,6 @@ use std::fmt;
 
 use style::Style;
 
-
 /// Styles have a special `Debug` implementation that only shows the fields that
 /// are set. Fields that haven’t been touched aren’t included in the output.
 ///
@@ -103,20 +102,33 @@ mod test {
 
     #[test]
     fn long_and_detailed() {
-        let debug = r##"Style {
-    foreground: Some(
-        Blue,
-    ),
-    background: None,
-    blink: false,
-    bold: true,
-    dimmed: false,
-    hidden: false,
-    italic: false,
-    reverse: false,
-    strikethrough: false,
-    underline: false,
-}"##;
-        assert_eq!(debug, format!("{:#?}", Blue.bold()));
+        extern crate regex;
+        let expected_debug = "Style { fg(Blue), bold }";
+        let expected_pretty_repat = r##"(?x)
+        Style\s+\{\s+
+            foreground:\s+Some\(\s+
+                Blue,?\s+
+            \),\s+
+            background:\s+None,\s+
+            blink:\s+false,\s+
+            bold:\s+true,\s+
+            dimmed:\s+false,\s+
+            hidden:\s+false,\s+
+            italic:\s+false,\s+
+            reverse:\s+false,\s+
+            strikethrough:\s+
+            false,\s+
+            underline:\s+false,?\s+
+            \}"##;
+        let re = regex::Regex::new(expected_pretty_repat).unwrap();
+
+        let style = Blue.bold();
+        let style_fmt_debug = format!("{:?}", style);
+        let style_fmt_pretty = format!("{:#?}", style);
+        println!("style_fmt_debug:\n{}", style_fmt_debug);
+        println!("style_fmt_pretty:\n{}", style_fmt_pretty);
+
+        assert_eq!(expected_debug, style_fmt_debug);
+        assert!(re.is_match(&style_fmt_pretty));
     }
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -16,8 +16,9 @@ pub fn enable_ansi_support() -> Result<(), u32> {
     use std::ptr::null_mut;
     use winapi::um::consoleapi::{GetConsoleMode, SetConsoleMode};
     use winapi::um::errhandlingapi::GetLastError;
-    use winapi::um::fileapi::CreateFile2;
+    use winapi::um::fileapi::{CreateFile2, OPEN_EXISTING};
     use winapi::um::handleapi::INVALID_HANDLE_VALUE;
+    use winapi::um::winnt::{FILE_SHARE_WRITE, GENERIC_READ, GENERIC_WRITE};
 
     const ENABLE_VIRTUAL_TERMINAL_PROCESSING: u32 = 0x0004;
 
@@ -27,9 +28,9 @@ pub fn enable_ansi_support() -> Result<(), u32> {
         let console_out_name: Vec<u16> = OsStr::new("CONOUT$").encode_wide().chain(once(0)).collect();
         let console_handle = CreateFile2(
             console_out_name.as_ptr(),
-            winapi::um::winnt::GENERIC_READ | winapi::um::winnt::GENERIC_WRITE,
-            winapi::um::winnt::FILE_SHARE_WRITE,
-            winapi::um::fileapi::OPEN_EXISTING,
+            GENERIC_READ | GENERIC_WRITE,
+            FILE_SHARE_WRITE,
+            OPEN_EXISTING,
             null_mut(),
         );
         if console_handle == INVALID_HANDLE_VALUE

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -16,21 +16,23 @@ pub fn enable_ansi_support() -> Result<(), u32> {
     use std::ptr::null_mut;
     use winapi::um::consoleapi::{GetConsoleMode, SetConsoleMode};
     use winapi::um::errhandlingapi::GetLastError;
-    use winapi::um::fileapi::{CreateFile2, OPEN_EXISTING};
+    use winapi::um::fileapi::{CreateFileW, OPEN_EXISTING};
     use winapi::um::handleapi::INVALID_HANDLE_VALUE;
     use winapi::um::winnt::{FILE_SHARE_WRITE, GENERIC_READ, GENERIC_WRITE};
 
     const ENABLE_VIRTUAL_TERMINAL_PROCESSING: u32 = 0x0004;
 
     unsafe {
-        // ref: https://docs.microsoft.com/en-us/windows/desktop/api/fileapi/nf-fileapi-createfile2
-        // Using `CreateFile2("CONOUT$", ...)` to retrieve the console handle works correctly even if STDOUT and/or STDERR are redirected
+        // ref: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew
+        // Using `CreateFileW("CONOUT$", ...)` to retrieve the console handle works correctly even if STDOUT and/or STDERR are redirected
         let console_out_name: Vec<u16> = OsStr::new("CONOUT$").encode_wide().chain(once(0)).collect();
-        let console_handle = CreateFile2(
+        let console_handle = CreateFileW(
             console_out_name.as_ptr(),
             GENERIC_READ | GENERIC_WRITE,
             FILE_SHARE_WRITE,
+            null_mut(),
             OPEN_EXISTING,
+            0,
             null_mut(),
         );
         if console_handle == INVALID_HANDLE_VALUE


### PR DESCRIPTION
This PR set fixes currrent windows compilation errors (see [AppVeyor build/test](https://ci.appveyor.com/project/rivy/rust-ansi-term/builds/26118094)) and increases backwards window version compatibility.
