### PR TITLE
fix: trait objects without an explicit `dyn`

### DIFF
--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -276,7 +276,7 @@ impl Colour {
 
 impl fmt::Display for Prefix {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let f: &mut fmt::Write = f;
+        let f: &mut dyn fmt::Write = f;
         self.0.write_prefix(f)
     }
 }
@@ -288,11 +288,11 @@ impl fmt::Display for Infix {
 
         match Difference::between(&self.0, &self.1) {
             Difference::ExtraStyles(style) => {
-                let f: &mut fmt::Write = f;
+                let f: &mut dyn fmt::Write = f;
                 style.write_prefix(f)
             },
             Difference::Reset => {
-                let f: &mut fmt::Write = f;
+                let f: &mut dyn fmt::Write = f;
                 write!(f, "{}{}", RESET, self.1.prefix())
             },
             Difference::NoDifference => {
@@ -305,7 +305,7 @@ impl fmt::Display for Infix {
 
 impl fmt::Display for Suffix {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let f: &mut fmt::Write = f;
+        let f: &mut dyn fmt::Write = f;
         self.0.write_suffix(f)
     }
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -198,7 +198,7 @@ impl Colour {
 
 impl<'a> fmt::Display for ANSIString<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let w: &mut fmt::Write = f;
+        let w: &mut dyn fmt::Write = f;
         self.write_to_any(w)
     }
 }
@@ -207,7 +207,7 @@ impl<'a> ANSIByteString<'a> {
     /// Write an `ANSIByteString` to an `io::Write`.  This writes the escape
     /// sequences for the associated `Style` around the bytes.
     pub fn write_to<W: io::Write>(&self, w: &mut W) -> io::Result<()> {
-        let w: &mut io::Write = w;
+        let w: &mut dyn io::Write = w;
         self.write_to_any(w)
     }
 }
@@ -226,7 +226,7 @@ where <S as ToOwned>::Owned: fmt::Debug, &'a S: AsRef<[u8]> {
 
 impl<'a> fmt::Display for ANSIStrings<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let f: &mut fmt::Write = f;
+        let f: &mut dyn fmt::Write = f;
         self.write_to_any(f)
     }
 }
@@ -236,7 +236,7 @@ impl<'a> ANSIByteStrings<'a> {
     /// escape sequences for the associated `Style`s around each set of
     /// bytes.
     pub fn write_to<W: io::Write>(&self, w: &mut W) -> io::Result<()> {
-        let w: &mut io::Write = w;
+        let w: &mut dyn io::Write = w;
         self.write_to_any(w)
     }
 }

--- a/src/write.rs
+++ b/src/write.rs
@@ -12,7 +12,7 @@ pub trait AnyWrite {
 }
 
 
-impl<'a> AnyWrite for fmt::Write + 'a {
+impl<'a> AnyWrite for dyn fmt::Write + 'a {
     type wstr = str;
     type Error = fmt::Error;
 
@@ -26,7 +26,7 @@ impl<'a> AnyWrite for fmt::Write + 'a {
 }
 
 
-impl<'a> AnyWrite for io::Write + 'a {
+impl<'a> AnyWrite for dyn io::Write + 'a {
     type wstr = [u8];
     type Error = io::Error;
 


### PR DESCRIPTION
Fixes: https://github.com/ogham/rust-ansi-term/issues/56

Notes:
* dyn syntax was introduced in v1.27.0: https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1270-2018-06-21
* rust-ansi-term supports minimum version rust@1.28.0 which supports dyn syntax https://github.com/ogham/rust-ansi-term/blob/ff7eba98d55ad609c7fcc8c7bb0859b37c7545cc/.appveyor.yml#L29