### PR TITLE
Replace "cfg(test)" with "cfg(doctest)" for readme testing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,11 +240,11 @@
 
 #[cfg(target_os="windows")]
 extern crate winapi;
-#[cfg(test)]
+#[cfg(doctest)]
 #[macro_use]
 extern crate doc_comment;
 
-#[cfg(test)]
+#[cfg(doctest)]
 doctest!("../README.md");
 
 mod ansi;


### PR DESCRIPTION
Rustdoc now passes "doctest" when running in test mode.