### PR TITLE
custom derserialize for support u8 and seq directly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,5 @@ features = ["consoleapi", "errhandlingapi", "fileapi", "handleapi", "processenv"
 [dev-dependencies]
 doc-comment = "0.3"
 regex = "1.1.9"
-
-[dev-dependencies.serde_json]
-version = "1.0.39"
+ryu = "<1.0.5"
+serde_json = "<1.0.45"


### PR DESCRIPTION
Hi,

 I have created a custom deserializer for `Colour`, after using the custom one, we can deserialize like below:

```json
{"colour": "Red"}
```

```json
{"colour": 255}
```

```json
{
  "colour": {
    "Fixed": 255
  }
}
```

```json
{"colour": [255,255,255]}
```

```json
{
  "colour": {
    "Red": [255,255,255]
  }
}
```

this keeps the compatibility and provided a more convenient way to deserialize `Colour`