### PR TITLE
Add optional support for ansi_colours crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,11 @@ version = "1.0.90"
 features = ["derive"]
 optional = true
 
+[dependencies.ansi_colours]
+version = "1.1.1"
+default-features = false
+optional = true
+
 [target.'cfg(target_os="windows")'.dependencies.winapi]
 version = "0.3.4"
 features = ["consoleapi", "errhandlingapi", "fileapi", "handleapi", "processenv"]

--- a/src/style.rs
+++ b/src/style.rs
@@ -458,6 +458,27 @@ impl Colour {
     pub fn on(self, background: Colour) -> Style {
         Style { foreground: Some(self), background: Some(background), .. Style::default() }
     }
+
+    /// Returns index in 256-colour ANSI palette or red, green and blue
+    /// components of the colour.
+    ///
+    /// Variants `Black` through `White` are treated as indexes 0 through 7.
+    /// Variant `Fixed` returns the index stored in it.  Lastly, `RGB` variant
+    /// is returned as a three-element tuple.
+    pub fn into_index(self) -> Result<u8, (u8, u8, u8)> {
+        match self {
+            Self::Black => Ok(0),
+            Self::Red => Ok(1),
+            Self::Green => Ok(2),
+            Self::Yellow => Ok(3),
+            Self::Blue => Ok(4),
+            Self::Purple => Ok(5),
+            Self::Cyan => Ok(6),
+            Self::White => Ok(7),
+            Self::Fixed(idx) => Ok(idx),
+            Self::RGB(r, g, b) => Err((r, g, b))
+        }
+    }
 }
 
 impl From<Colour> for Style {


### PR DESCRIPTION
Add Colour::approx_rgb and Colour::into_256 which convert RGB variant
into Fixed variant.  This is useful when an application is running on
a terminal which does not support True Colour control codes.  By using
the approximation the utility can fallback to using 256-colour palette
which is more widely supported.

Furthermore, add Colour::into_rgb method which performs conversion in
the opposite direction.  Naturally, the results for the first 16
colours aren’t exactly reliable (since those colours can be configured
by the user) but indexes from the 6×6x6 cube or greyscale ramp will be
returned correctly.