### PR TITLE
Add a no-op `enable_ansi_support` for non-windows platforms

### DIFF
--- a/src/windows.rs
+++ b/src/windows.rs
@@ -59,3 +59,10 @@ pub fn enable_ansi_support() -> Result<(), u32> {
 
     return Ok(());
 }
+
+/// Enable ANSI support on Windows 10. This is a no-op on non-windows platforms
+#[cfg(not(windows))]
+#[inline]
+pub fn enable_ansi_support() -> Result<(), u32> {
+    Ok(())
+}


### PR DESCRIPTION
Added `enable_ansi_support` on non-windows platforms, so that the crate is easier to use on those platforms.