### PR TITLE
Add "bright" builtin codes and tests.

### DIFF
--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -90,6 +90,15 @@ impl Colour {
             Colour::Purple     => write!(f, "35"),
             Colour::Cyan       => write!(f, "36"),
             Colour::White      => write!(f, "37"),
+
+            Colour::BrightBlack      => write!(f, "90"),
+            Colour::BrightRed        => write!(f, "91"),
+            Colour::BrightGreen      => write!(f, "92"),
+            Colour::BrightYellow     => write!(f, "93"),
+            Colour::BrightBlue       => write!(f, "94"),
+            Colour::BrightPurple     => write!(f, "95"),
+            Colour::BrightCyan       => write!(f, "96"),
+            Colour::BrightWhite      => write!(f, "97"),
             Colour::Fixed(num) => write!(f, "38;5;{}", &num),
             Colour::RGB(r,g,b) => write!(f, "38;2;{};{};{}", &r, &g, &b),
         }
@@ -105,6 +114,14 @@ impl Colour {
             Colour::Purple     => write!(f, "45"),
             Colour::Cyan       => write!(f, "46"),
             Colour::White      => write!(f, "47"),
+            Colour::BrightBlack      => write!(f, "100"),
+            Colour::BrightRed        => write!(f, "101"),
+            Colour::BrightGreen      => write!(f, "102"),
+            Colour::BrightYellow     => write!(f, "103"),
+            Colour::BrightBlue       => write!(f, "104"),
+            Colour::BrightPurple     => write!(f, "105"),
+            Colour::BrightCyan       => write!(f, "106"),
+            Colour::BrightWhite      => write!(f, "107"),
             Colour::Fixed(num) => write!(f, "48;5;{}", &num),
             Colour::RGB(r,g,b) => write!(f, "48;2;{};{};{}", &r, &g, &b),
         }
@@ -330,38 +347,40 @@ mod test {
         };
     }
 
-    test!(plain:                 Style::default();                  "text/plain" => "text/plain");
-    test!(red:                   Red;                               "hi" => "\x1B[31mhi\x1B[0m");
-    test!(black:                 Black.normal();                    "hi" => "\x1B[30mhi\x1B[0m");
-    test!(yellow_bold:           Yellow.bold();                     "hi" => "\x1B[1;33mhi\x1B[0m");
-    test!(yellow_bold_2:         Yellow.normal().bold();            "hi" => "\x1B[1;33mhi\x1B[0m");
-    test!(blue_underline:        Blue.underline();                  "hi" => "\x1B[4;34mhi\x1B[0m");
-    test!(green_bold_ul:         Green.bold().underline();          "hi" => "\x1B[1;4;32mhi\x1B[0m");
-    test!(green_bold_ul_2:       Green.underline().bold();          "hi" => "\x1B[1;4;32mhi\x1B[0m");
-    test!(purple_on_white:       Purple.on(White);                  "hi" => "\x1B[47;35mhi\x1B[0m");
-    test!(purple_on_white_2:     Purple.normal().on(White);         "hi" => "\x1B[47;35mhi\x1B[0m");
-    test!(yellow_on_blue:        Style::new().on(Blue).fg(Yellow);  "hi" => "\x1B[44;33mhi\x1B[0m");
-    test!(yellow_on_blue_2:      Cyan.on(Blue).fg(Yellow);          "hi" => "\x1B[44;33mhi\x1B[0m");
-    test!(cyan_bold_on_white:    Cyan.bold().on(White);             "hi" => "\x1B[1;47;36mhi\x1B[0m");
-    test!(cyan_ul_on_white:      Cyan.underline().on(White);        "hi" => "\x1B[4;47;36mhi\x1B[0m");
-    test!(cyan_bold_ul_on_white: Cyan.bold().underline().on(White); "hi" => "\x1B[1;4;47;36mhi\x1B[0m");
-    test!(cyan_ul_bold_on_white: Cyan.underline().bold().on(White); "hi" => "\x1B[1;4;47;36mhi\x1B[0m");
-    test!(fixed:                 Fixed(100);                        "hi" => "\x1B[38;5;100mhi\x1B[0m");
-    test!(fixed_on_purple:       Fixed(100).on(Purple);             "hi" => "\x1B[45;38;5;100mhi\x1B[0m");
-    test!(fixed_on_fixed:        Fixed(100).on(Fixed(200));         "hi" => "\x1B[48;5;200;38;5;100mhi\x1B[0m");
-    test!(rgb:                   RGB(70,130,180);                   "hi" => "\x1B[38;2;70;130;180mhi\x1B[0m");
-    test!(rgb_on_blue:           RGB(70,130,180).on(Blue);          "hi" => "\x1B[44;38;2;70;130;180mhi\x1B[0m");
-    test!(blue_on_rgb:           Blue.on(RGB(70,130,180));          "hi" => "\x1B[48;2;70;130;180;34mhi\x1B[0m");
-    test!(rgb_on_rgb:            RGB(70,130,180).on(RGB(5,10,15));  "hi" => "\x1B[48;2;5;10;15;38;2;70;130;180mhi\x1B[0m");
-    test!(bold:                  Style::new().bold();               "hi" => "\x1B[1mhi\x1B[0m");
-    test!(underline:             Style::new().underline();          "hi" => "\x1B[4mhi\x1B[0m");
-    test!(bunderline:            Style::new().bold().underline();   "hi" => "\x1B[1;4mhi\x1B[0m");
-    test!(dimmed:                Style::new().dimmed();             "hi" => "\x1B[2mhi\x1B[0m");
-    test!(italic:                Style::new().italic();             "hi" => "\x1B[3mhi\x1B[0m");
-    test!(blink:                 Style::new().blink();              "hi" => "\x1B[5mhi\x1B[0m");
-    test!(reverse:               Style::new().reverse();            "hi" => "\x1B[7mhi\x1B[0m");
-    test!(hidden:                Style::new().hidden();             "hi" => "\x1B[8mhi\x1B[0m");
-    test!(stricken:              Style::new().strikethrough();      "hi" => "\x1B[9mhi\x1B[0m");
+    test!(plain:                    Style::default();                  "text/plain" => "text/plain");
+    test!(red:                      Red;                               "hi" => "\x1B[31mhi\x1B[0m");
+    test!(black:                    Black.normal();                    "hi" => "\x1B[30mhi\x1B[0m");
+    test!(yellow_bold:              Yellow.bold();                     "hi" => "\x1B[1;33mhi\x1B[0m");
+    test!(yellow_bold_2:            Yellow.normal().bold();            "hi" => "\x1B[1;33mhi\x1B[0m");
+    test!(blue_underline:           Blue.underline();                  "hi" => "\x1B[4;34mhi\x1B[0m");
+    test!(green_bold_ul:            Green.bold().underline();          "hi" => "\x1B[1;4;32mhi\x1B[0m");
+    test!(green_bold_ul_2:          Green.underline().bold();          "hi" => "\x1B[1;4;32mhi\x1B[0m");
+    test!(purple_on_white:          Purple.on(White);                  "hi" => "\x1B[47;35mhi\x1B[0m");
+    test!(purple_on_white_2:        Purple.normal().on(White);         "hi" => "\x1B[47;35mhi\x1B[0m");
+    test!(yellow_on_blue:           Style::new().on(Blue).fg(Yellow);  "hi" => "\x1B[44;33mhi\x1B[0m");
+    test!(yellow_on_blue_2:         Cyan.on(Blue).fg(Yellow);          "hi" => "\x1B[44;33mhi\x1B[0m");
+    test!(cyan_bold_on_white:       Cyan.bold().on(White);             "hi" => "\x1B[1;47;36mhi\x1B[0m");
+    test!(cyan_ul_on_white:         Cyan.underline().on(White);        "hi" => "\x1B[4;47;36mhi\x1B[0m");
+    test!(cyan_bold_ul_on_white:    Cyan.bold().underline().on(White); "hi" => "\x1B[1;4;47;36mhi\x1B[0m");
+    test!(cyan_ul_bold_on_white:    Cyan.underline().bold().on(White); "hi" => "\x1B[1;4;47;36mhi\x1B[0m");
+    test!(fixed:                    Fixed(100);                        "hi" => "\x1B[38;5;100mhi\x1B[0m");
+    test!(fixed_on_purple:          Fixed(100).on(Purple);             "hi" => "\x1B[45;38;5;100mhi\x1B[0m");
+    test!(fixed_on_fixed:           Fixed(100).on(Fixed(200));         "hi" => "\x1B[48;5;200;38;5;100mhi\x1B[0m");
+    test!(rgb:                      RGB(70,130,180);                   "hi" => "\x1B[38;2;70;130;180mhi\x1B[0m");
+    test!(rgb_on_blue:              RGB(70,130,180).on(Blue);          "hi" => "\x1B[44;38;2;70;130;180mhi\x1B[0m");
+    test!(blue_on_rgb:              Blue.on(RGB(70,130,180));          "hi" => "\x1B[48;2;70;130;180;34mhi\x1B[0m");
+    test!(rgb_on_rgb:               RGB(70,130,180).on(RGB(5,10,15));  "hi" => "\x1B[48;2;5;10;15;38;2;70;130;180mhi\x1B[0m");
+    test!(bold:                     Style::new().bold();               "hi" => "\x1B[1mhi\x1B[0m");
+    test!(underline:                Style::new().underline();          "hi" => "\x1B[4mhi\x1B[0m");
+    test!(bunderline:               Style::new().bold().underline();   "hi" => "\x1B[1;4mhi\x1B[0m");
+    test!(dimmed:                   Style::new().dimmed();             "hi" => "\x1B[2mhi\x1B[0m");
+    test!(italic:                   Style::new().italic();             "hi" => "\x1B[3mhi\x1B[0m");
+    test!(blink:                    Style::new().blink();              "hi" => "\x1B[5mhi\x1B[0m");
+    test!(reverse:                  Style::new().reverse();            "hi" => "\x1B[7mhi\x1B[0m");
+    test!(hidden:                   Style::new().hidden();             "hi" => "\x1B[8mhi\x1B[0m");
+    test!(stricken:                 Style::new().strikethrough();      "hi" => "\x1B[9mhi\x1B[0m");
+    test!(brightgreen:              BrightGreen;                       "hi" => "\x1B[92mhi\x1B[0m");
+    test!(brightred_on_brightblue:  BrightRed.on(BrightBlue);          "hi" => "\x1B[104;91mhi\x1B[0m");
 
     #[test]
     fn test_infix() {

--- a/src/style.rs
+++ b/src/style.rs
@@ -285,6 +285,36 @@ pub enum Colour {
     /// hard to read on terminals with light backgrounds.
     White,
 
+    /// Colour #8 (foreground code `30`, background code `40`).
+    ///
+    /// This is not necessarily the background colour, and using it as one may
+    /// render the text hard to read on terminals with dark backgrounds.
+    BrightBlack,
+
+    /// Colour #9 (foreground code `91`, background code `101`).
+    BrightRed,
+
+    /// Colour #10 (foreground code `92`, background code `102`).
+    BrightGreen,
+
+    /// Colour #11 (foreground code `93`, background code `103`).
+    BrightYellow,
+
+    /// Colour #12 (foreground code `94`, background code `104`).
+    BrightBlue,
+
+    /// Colour #13 (foreground code `95`, background code `105`).
+    BrightPurple,
+
+    /// Colour #14 (foreground code `96`, background code `106`).
+    BrightCyan,
+
+    /// Colour #15 (foreground code `97`, background code `107`).
+    ///
+    /// As above, this is not necessarily the foreground colour, and may be
+    /// hard to read on terminals with light backgrounds.
+    BrightWhite,
+
     /// A colour number from 0 to 255, for use in 256-colour terminal
     /// environments.
     ///


### PR DESCRIPTION
Implement bright color variants with codes 90-97 and 100-107 for foreground and background, respectively.

It is a little inelegant, in that I just copy-pasted and incremented the numbers.