### PR TITLE
Move from winapi to windows-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,9 @@ version = "1.0.90"
 features = ["derive"]
 optional = true
 
-[target.'cfg(target_os="windows")'.dependencies.winapi]
-version = "0.3.4"
-features = ["consoleapi", "errhandlingapi", "fileapi", "handleapi", "processenv"]
+[target.'cfg(target_os="windows")'.dependencies.windows-sys]
+version = "0.59"
+features = ["Win32_System_Console", "Win32_Storage_FileSystem", "Win32_Security"]
 
 [dev-dependencies]
 doc-comment = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,7 +239,7 @@
 #![warn(unused_extern_crates, unused_qualifications)]
 
 #[cfg(target_os="windows")]
-extern crate winapi;
+extern crate windows_sys;
 #[cfg(test)]
 #[macro_use]
 extern crate doc_comment;

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -14,11 +14,9 @@ pub fn enable_ansi_support() -> Result<(), u32> {
     use std::iter::once;
     use std::os::windows::ffi::OsStrExt;
     use std::ptr::null_mut;
-    use winapi::um::consoleapi::{GetConsoleMode, SetConsoleMode};
-    use winapi::um::errhandlingapi::GetLastError;
-    use winapi::um::fileapi::{CreateFileW, OPEN_EXISTING};
-    use winapi::um::handleapi::INVALID_HANDLE_VALUE;
-    use winapi::um::winnt::{FILE_SHARE_WRITE, GENERIC_READ, GENERIC_WRITE};
+    use windows_sys::Win32::System::Console::{GetConsoleMode, SetConsoleMode};
+    use windows_sys::Win32::Foundation::{GetLastError, INVALID_HANDLE_VALUE, GENERIC_READ, GENERIC_WRITE};
+    use windows_sys::Win32::Storage::FileSystem::{CreateFileW, OPEN_EXISTING, FILE_SHARE_WRITE};
 
     const ENABLE_VIRTUAL_TERMINAL_PROCESSING: u32 = 0x0004;
 


### PR DESCRIPTION
`winapi` hasn't been maintained for a number of years so most people are switching to `windows-sys`. Using the more common crate here reduces the chances of having to include both `winapi` and `windows-sys` in builds that depend on `rust-ansi-term`.
